### PR TITLE
Fixing possible copy-paste mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ or
 
 ### Automatic installation
 
-`$ react-native link react-native-alarm`
+`$ react-native link react-native-alarm-clock`
 
 ### Manual installation
 


### PR DESCRIPTION
Found a possible copy-paste mistake in README.md. The file mentions `react-native link react-native-alarm` whereas I think it should be `react-native link react-native-alarm-clock`.